### PR TITLE
Add command to quit/exit explore

### DIFF
--- a/explore.py
+++ b/explore.py
@@ -57,3 +57,6 @@ while not quit:
             path = path[:-1]
             csd = path[-1]
 
+    if cmd[0] == 'quit' or cmd[0] == 'exit':
+        quit = True
+


### PR DESCRIPTION
Found that there was no convenient way to exit explore so added commands 'quit' and 'exit' to do this